### PR TITLE
Make poise-service providers why-runnable

### DIFF
--- a/lib/poise_service/service_providers/base.rb
+++ b/lib/poise_service/service_providers/base.rb
@@ -191,6 +191,10 @@ module PoiseService
         end
       end
 
+      def whyrun_supported?
+          true
+      end
+
     end
   end
 end


### PR DESCRIPTION
Enable the --why-run option of chef-client and allow client code to be
able to use the converge_by method.
It is safe in systemd since the called resources are primitives and
idempotency is then guaranteed.